### PR TITLE
Add filter and update actions in BarangResource

### DIFF
--- a/app/Filament/Resources/BarangResource.php
+++ b/app/Filament/Resources/BarangResource.php
@@ -6,6 +6,7 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\BarangResource\Pages;
 use App\Models\Barang;
+use App\Models\JenisBantuan;
 use App\Models\Kelurahan;
 use App\Supports\Helpers;
 use Awcodes\FilamentBadgeableColumn\Components\Badge;
@@ -140,6 +141,11 @@ class BarangResource extends Resource
                 Tables\Filters\SelectFilter::make('kode_kelurahan')
                     ->label('Kelurahan')
                     ->options(Kelurahan::query()->whereIn('kecamatan_code', config('custom.kode_kecamatan'))->pluck('name', 'code'))
+                    ->searchable()
+                    ->preload(),
+                Tables\Filters\SelectFilter::make('jenis_bantuan_id')
+                    ->label('Jenis Bantuan')
+                    ->options(JenisBantuan::pluck('alias', 'id'))
                     ->searchable()
                     ->preload(),
             ])

--- a/app/Filament/Resources/BarangResource/Pages/ManageBarangs.php
+++ b/app/Filament/Resources/BarangResource/Pages/ManageBarangs.php
@@ -54,8 +54,8 @@ class ManageBarangs extends ManageRecords
     {
         return [
             Actions\Action::make('generate item bantuan')
-                ->label('Generate Item Bantuan Per Kelurahan')
-                ->color('warning')
+                ->label('Generate Item Bantuan Semua Kelurahan')
+                ->color('secondary')
                 ->form([
                     Section::make()->schema([
                         Select::make('jenis_bantuan')
@@ -92,7 +92,7 @@ class ManageBarangs extends ManageRecords
                         ->send();
                 })
                 ->visible(fn() => auth()->user()->hasRole(superadmin_admin_roles()))
-                ->icon('heroicon-o-document-duplicate'),
+                ->icon('heroicon-o-plus'),
             Actions\CreateAction::make()
                 ->icon('heroicon-o-plus')
                 ->mutateFormDataUsing(function (array $data) {


### PR DESCRIPTION
### Changes introduced in this PR

- Added `jenis_bantuan` filter to BarangResource for filtering data based on assistance types.
- Updated labels and icons on "Generate Item Bantuan" action to better reflect its purpose.

### Checklist

- [ ] Tests added or updated where necessary.
- [ ] Documentation updated if applicable.
- [ ] Verified functionality in local environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Jenis Bantuan" (Kind of Assistance) filter to the grid, allowing users to filter items by assistance type.
  * Enhanced item generation action to now generate items across all regions in a single operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->